### PR TITLE
Adopt directory naming convention

### DIFF
--- a/all.py
+++ b/all.py
@@ -2,5 +2,4 @@
 Finitely presented modules over the Steenrod algebra 
 """
 from sage.misc.lazy_import import lazy_import
-lazy_import('sage.modules.fp_modules.fpa_module', 'FPA_Module')
-
+lazy_import('sage.modules.finitely_presented_over_the_steenrod_algebra.fpa_module', 'FPA_Module')

--- a/fp_element.py
+++ b/fp_element.py
@@ -87,7 +87,7 @@ class FP_Element(SageModuleElement):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import FP_Module
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import FP_Module
             sage: M = FP_Module([0,2,4], SteenrodAlgebra(2), [[Sq(4),Sq(2),0]])
             sage: M(0)._nonzero_()
             False
@@ -114,7 +114,7 @@ class FP_Element(SageModuleElement):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import FP_Module
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import FP_Module
             sage: M = FP_Module([0,2,4], SteenrodAlgebra(2), [[Sq(4),Sq(2),0]])
             sage: m = M((Sq(6), 0, Sq(2)))
             sage: m; m.normalize()

--- a/fp_homspace.py
+++ b/fp_homspace.py
@@ -8,7 +8,7 @@ from sage.misc.cachefunc import cached_method
 r"""
 TESTS::
 
-    sage: from sage.modules.fp_modules.fp_module import FP_Module
+    sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import FP_Module
     sage: from sage.misc.sage_unittest import TestSuite
     sage: A = SteenrodAlgebra(2, profile=(3,2,1))
     sage: F = FP_Module([1,3], A)

--- a/fp_module.py
+++ b/fp_module.py
@@ -74,7 +74,7 @@ def FP_Module(generator_degrees, algebra, relations=()):
     presentation given by ``generators`` and ``relations``.
 
     EXAMPLES::
-        sage: from sage.modules.fp_modules.fp_module import FP_Module
+        sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import FP_Module
         sage: A4 = SteenrodAlgebra(2, profile=(4,3,2,1))
         sage: M = FP_Module([0, 1], A4, [[Sq(2), Sq(1)]])
         sage: M.generators()
@@ -169,7 +169,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A = SteenrodAlgebra(2)
             sage: A3 = SteenrodAlgebra(2,profile=(3,2,1))
             sage: M = FP_Module([0,1], A, [[Sq(2), Sq(1)]])
@@ -198,23 +198,23 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A = SteenrodAlgebra(2)
             sage: M = FP_Module([0,2,4], A, [[Sq(4), Sq(2), 0]])
             sage: e = M(0); e
             <0, 0, 0>
             sage: type(e)
-            <class 'sage.modules.fp_modules.fp_module.FP_Module_class_with_category.element_class'>
+            <class 'sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module.FP_Module_class_with_category.element_class'>
             sage: f = M((Sq(6), 0, Sq(2))); f
             <Sq(6), 0, Sq(2)>
             sage: type(f)
-            <class 'sage.modules.fp_modules.fp_module.FP_Module_class_with_category.element_class'>
+            <class 'sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module.FP_Module_class_with_category.element_class'>
             sage: g = M((Sq(6), 0, Sq(2))); g
             <Sq(6), 0, Sq(2)>
             sage: M(g)
             <Sq(6), 0, Sq(2)>
             sage: type(g)
-            <class 'sage.modules.fp_modules.fp_module.FP_Module_class_with_category.element_class'>
+            <class 'sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module.FP_Module_class_with_category.element_class'>
 
         """
 
@@ -233,7 +233,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A = SteenrodAlgebra(2)
             sage: M = FP_Module([0,2,4], A, [[Sq(4),Sq(2),0]]); M
             Finitely presented module on 3 generators and 1 relation over mod 2 Steenrod algebra, milnor basis
@@ -253,7 +253,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES:
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A = SteenrodAlgebra(2)
             sage: M = FP_Module([0,2,4], A, [[0, Sq(5), Sq(3)], [Sq(7), 0, Sq(2)*Sq(1)]])
             sage: M.connectivity()
@@ -301,7 +301,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A = SteenrodAlgebra(2)
             sage: A3 = SteenrodAlgebra(2, profile=(3,2,1))
             sage: M = FP_Module([], A3)
@@ -344,7 +344,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A3 = SteenrodAlgebra(2, profile=(3,2,1))
             sage: F = FP_Module([1,2], A3)
             sage: F.has_relations()
@@ -373,7 +373,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A3 = SteenrodAlgebra(2, profile=(3,2,1))
             sage: M = FP_Module([0,2,4], A3, [[0, Sq(5), Sq(3)], [Sq(7), 0, Sq(2)*Sq(1)]])
             sage: M.zero()
@@ -402,7 +402,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A3 = SteenrodAlgebra(2, profile=(3,2,1))
             sage: M = FP_Module([0,2], A3, [[Sq(4), Sq(2)], [0, Sq(6)]])
             sage: M.basis_elements(4)
@@ -441,7 +441,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES:
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A = SteenrodAlgebra(2)
             sage: M = FP_Module([0], A, [[Sq(4)], [Sq(7)], [Sq(4)*Sq(9)]])
             sage: M.vector_presentation(12).dimension()
@@ -453,7 +453,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         .. SEEALSO::
 
-            :meth:`sage.modules.fp_modules.fp_module.vector_presentation`,
+            :meth:`sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module.vector_presentation`,
 
         """
         M_n = self.vector_presentation(n)
@@ -485,7 +485,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A = SteenrodAlgebra(2)
             sage: M = FP_Module([0,2,4], A, [[Sq(4),Sq(2),0]])
             sage: V = M.vector_presentation(4)
@@ -534,7 +534,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         TESTS::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A = SteenrodAlgebra(2)
             sage: F = FP_Module([1,3], A);
             sage: L = FP_Module([2,3], A, [[Sq(2),Sq(1)], [0,Sq(2)]]);
@@ -556,7 +556,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A4 = SteenrodAlgebra(2, profile=(4,3,2,1))
             sage: N = FP_Module([0, 1], A4, [[Sq(2), Sq(1)]])
             sage: N.generator_degrees()
@@ -573,7 +573,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A4 = SteenrodAlgebra(2, profile=(4,3,2,1))
             sage: M = FP_Module([0,2,3], A4)
             sage: M.generators()
@@ -595,7 +595,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A4 = SteenrodAlgebra(2, profile=(4,3,2,1))
             sage: M = FP_Module([0,2,3], A4); M.generator(0)
             <1, 0, 0>
@@ -612,7 +612,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A4 = SteenrodAlgebra(2, profile=(4,3,2,1))
             sage: M = FP_Module([0,2,3], A4)
             sage: M.relations()
@@ -634,7 +634,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A4 = SteenrodAlgebra(2, profile=(4,3,2,1))
             sage: N = FP_Module([0, 1], A4, [[Sq(2), Sq(1)]])
             sage: N.relation(0)
@@ -655,7 +655,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A3 = SteenrodAlgebra(2, profile=(3,2,1))
             sage: M = FP_Module([0,1], A3, [[Sq(2),Sq(1)],[0,Sq(2)],[Sq(3),0]])
             sage: i = M.min_pres()
@@ -692,7 +692,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A = SteenrodAlgebra(2)
             sage: A3 = SteenrodAlgebra(2, profile=(3,2,1))
             sage: Y = FP_Module([0], A3, [[Sq(1)]])
@@ -736,7 +736,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A3 = SteenrodAlgebra(2, profile=(3,2,1))
             sage: M = FP_Module([0,1], A3, [[Sq(2),Sq(1)]])
             sage: i = M.submodule([M.generator(0)])
@@ -782,7 +782,7 @@ class FP_Module_class(UniqueRepresentation, SageModule):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A2 = SteenrodAlgebra(2, profile=(3,2,1))
             sage: M = FP_Module([0,1], A2, [[Sq(2), Sq(1)]])
             sage: M.resolution(0)

--- a/fp_morphism.py
+++ b/fp_morphism.py
@@ -5,7 +5,7 @@ r"""
 
 EXAMPLES::
 
-    sage: from sage.modules.fp_modules.fp_module import FP_Module
+    sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import FP_Module
     sage: A = SteenrodAlgebra(2)
     sage: F1 = FP_Module([4,5], A)
     sage: F2 = FP_Module([3,4], A)
@@ -123,7 +123,7 @@ class FP_ModuleMorphism(SageMorphism):
 
 
         TESTS:
-            sage: from sage.modules.fp_modules.fp_module import FP_Module
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import FP_Module
             sage: # Trying to map the generators of a non-free module into a
             sage: # free module:
             sage: A = SteenrodAlgebra(2)
@@ -359,7 +359,7 @@ class FP_ModuleMorphism(SageMorphism):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A = SteenrodAlgebra(2)
             sage: F1 = FP_Module((4,5), A)
             sage: F2 = FP_Module((3,4), A)
@@ -432,7 +432,7 @@ class FP_ModuleMorphism(SageMorphism):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A3 = SteenrodAlgebra(2, profile=(4,3,2,1))
             sage: F = FP_Module([1,3], A3);
             sage: L = FP_Module([2,3], A3, [[Sq(2),Sq(1)], [0,Sq(2)]]);
@@ -486,7 +486,7 @@ class FP_ModuleMorphism(SageMorphism):
                 onto the image of this homomorphism.
 
         EXAMPLES:
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A3 = SteenrodAlgebra(2, profile=(4,3,2,1))
             sage: F = FP_Module([1,3], A3);
             sage: L = FP_Module([2,3], A3, [[Sq(2),Sq(1)], [0,Sq(2)]]);
@@ -671,7 +671,7 @@ class FP_ModuleMorphism(SageMorphism):
 
 
         TESTS::
-            sage: from sage.modules.fp_modules.fp_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fp_module import *
             sage: A3 = SteenrodAlgebra(2, profile=(4,3,2,1))
             sage: F = FP_Module([0,0], A3)
             sage: L = FP_Module([0,0], A3, [[Sq(3),Sq(0,1)], [0,Sq(2)]])

--- a/fpa_module.py
+++ b/fpa_module.py
@@ -41,7 +41,7 @@ prime field.
 
 Creating a module class instance with given generators and relations::
 
-    sage: from sage.modules.fp_modules.fpa_module import FPA_Module
+    sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fpa_module import FPA_Module
     sage: A = SteenrodAlgebra(2)
     sage: M = FPA_Module([0,1], A, [[Sq(2),Sq(1)], [0,Sq(2)]]); M
     Finitely presented module on 2 generators and 2 relations over mod 2 Steenrod algebra, milnor basis
@@ -160,7 +160,7 @@ The category framework::
     sage: M = FPA_Module([2,3], A, [[Sq(2),Sq(1)]]);M
     Finitely presented module on 2 generators and 1 relation ...
     sage: K.element_class
-    <class 'sage.modules.fp_modules.fpa_module.FPA_Module_class_with_category.element_class'>
+    <class 'sage.modules.finitely_presented_over_the_steenrod_algebra.fpa_module.FPA_Module_class_with_category.element_class'>
     sage: m = M((0,1)); m
     <0, 1>
     sage: K.is_parent_of(m)
@@ -332,14 +332,14 @@ class FPA_Module_class(FP_Module_class):
         A finite profile over which this module can be defined.
 
         EXAMPLES::
-            sage: from sage.modules.fp_modules.fpa_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fpa_module import *
             sage: A = SteenrodAlgebra(2)
             sage: M = FPA_Module([0,1], A, [[Sq(2),Sq(1)],[0,Sq(2)],[Sq(3),0]])
             sage: M.profile()
             (2, 1)
 
         TESTS::
-            sage: from sage.modules.fp_modules.fpa_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fpa_module import *
             sage: A = SteenrodAlgebra(2)
             sage: X = FPA_Module([0], A)
             sage: X.profile()
@@ -371,7 +371,7 @@ class FPA_Module_class(FP_Module_class):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fpa_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fpa_module import *
             sage: A = SteenrodAlgebra(2)
             sage: M = FPA_Module([0,1], A, [[Sq(2),Sq(1)],[0,Sq(2)],[Sq(3),0]])
             sage: i = M.min_pres()
@@ -419,7 +419,7 @@ class FPA_Module_class(FP_Module_class):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fpa_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fpa_module import *
             sage: A = SteenrodAlgebra(2)
             sage: Hko = FPA_Module([0], A, [[Sq(1)], [Sq(2)]])
             sage: res = Hko.resolution(5, verbose=True)
@@ -478,7 +478,7 @@ class FPA_Module_class(FP_Module_class):
 
         EXAMPLES::
 
-            sage: from sage.modules.fp_modules.fpa_module import *
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fpa_module import *
             sage: A1 = algebra=SteenrodAlgebra(p=2, profile=[2,1])
             sage: M = FPA_Module([0], A1)
             sage: M.export_module_definition()

--- a/fpa_morphism.py
+++ b/fpa_morphism.py
@@ -50,7 +50,7 @@ class FPA_ModuleMorphism(FP_ModuleMorphism):
         A finite profile over which this homomorphism can be defined.
 
         EXAMPLES::
-            sage: from sage.modules.fp_modules.fpa_module import FPA_Module
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fpa_module import FPA_Module
             sage: A = SteenrodAlgebra(2)
             sage: M = FPA_Module([0,1], A, [[Sq(2),Sq(1)], [0,Sq(2)]])
             sage: id = Hom(M,M).identity()
@@ -107,7 +107,7 @@ class FPA_ModuleMorphism(FP_ModuleMorphism):
         Return True if and only if this homomorphism has a trivial kernel.
     
         EXAMPLES::
-            sage: from sage.modules.fp_modules.fpa_module import FPA_Module
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fpa_module import FPA_Module
             sage: A = SteenrodAlgebra(2)
             sage: M = FPA_Module([0,1], A, [[Sq(2),Sq(1)], [0,Sq(2)]])
             sage: S = FPA_Module([0], A, [[Sq(2)]])
@@ -145,7 +145,7 @@ class FPA_ModuleMorphism(FP_ModuleMorphism):
         onto the kernel of this homomorphism.
 
         EXAMPLES::
-            sage: from sage.modules.fp_modules.fpa_module import FPA_Module
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fpa_module import FPA_Module
             sage: A = SteenrodAlgebra(2)
             sage: M = FPA_Module([0,1], A, [[Sq(2),Sq(1)], [0,Sq(2)]])
             sage: S = FPA_Module([0], A, [[Sq(2)]])
@@ -190,7 +190,7 @@ class FPA_ModuleMorphism(FP_ModuleMorphism):
         onto the image of this homomorphism.
 
         EXAMPLES::
-            sage: from sage.modules.fp_modules.fpa_module import FPA_Module
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.fpa_module import FPA_Module
             sage: A = SteenrodAlgebra(2)
             sage: M = FPA_Module([0,1], A, [[Sq(2),Sq(1)], [0,Sq(2)]])
             sage: S = FPA_Module([0], A, [[Sq(2)]])

--- a/free_homspace.py
+++ b/free_homspace.py
@@ -11,7 +11,7 @@ from sage.categories.homset import Homset
 r"""
 TESTS::
 
-    sage: from sage.modules.fp_modules.free_module import FreeModule
+    sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.free_module import FreeModule
     sage: from sage.misc.sage_unittest import TestSuite
     sage: A = SteenrodAlgebra(2)
     sage: F1 = FreeModule((1,3), A);

--- a/free_morphism.py
+++ b/free_morphism.py
@@ -48,7 +48,7 @@ class FreeModuleMorphism(SageMorphism):
 
         EXAMPLES:
 
-            sage: from sage.modules.fp_modules.free_module import FreeModule
+            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.free_module import FreeModule
             sage: A = SteenrodAlgebra(2)
             sage: F1 = FreeModule((4,5), A)
             sage: F2 = FreeModule((3,4), A)

--- a/profile.py
+++ b/profile.py
@@ -20,7 +20,7 @@ def mod_p_log(n,p):
 
     EXAMPLES::
 
-        sage: from sage.modules.fp_modules.profile import *
+        sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.profile import *
         sage: mod_p_log(1,4)
         1
         sage: mod_p_log(8,3)
@@ -53,7 +53,7 @@ def profile_ele(alist,char=2):
 
     EXAMPLES::
 
-        sage: from sage.modules.fp_modules.profile import *
+        sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.profile import *
         sage: A2 = SteenrodAlgebra(2)
         sage: profile_ele(A2.Sq(2))
         (2, 1)
@@ -107,7 +107,7 @@ def enveloping_profile_elements(alist,char=2):
 
     EXAMPLES::
 
-        sage: from sage.modules.fp_modules.profile import *
+        sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.profile import *
         sage: enveloping_profile_elements([Sq(2),Sq(4)])
         (3, 2, 1)
         sage: enveloping_profile_elements([Sq(2,1,2),Sq(7)])
@@ -154,7 +154,7 @@ def enveloping_profile_profiles(alist,char=2):
 
     EXAMPLES::
 
-        sage: from sage.modules.fp_modules.profile import *
+        sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.profile import *
         sage: enveloping_profile_profiles([[1,2,3],[2,4,1,1]])
         (2, 4, 3, 2, 1)
         sage: enveloping_profile_profiles([[4],[1,2,1],[3,2,3]])
@@ -196,7 +196,7 @@ def valid(LL,char=2):
 
     EXAMPLES::
 
-        sage: from sage.modules.fp_modules.profile import *
+        sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.profile import *
         sage: valid([3,2,1])
         True
         sage: valid([1,2,3])
@@ -244,7 +244,7 @@ def nextprof(p,n,char=2):
 
     EXAMPLES::
 
-        sage: from sage.modules.fp_modules.profile import *
+        sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.profile import *
         sage: nextprof([1,2],[1,2])
         [2, 2]
         sage: nextprof([2,2],[1,2])
@@ -298,7 +298,7 @@ def find_min_profile(prof,char=2):
 
     EXAMPLES::
 
-        sage: from sage.modules.fp_modules.profile import *
+        sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.profile import *
         sage: find_min_profile([1,2])
         (1, 2, 1)
         sage: find_min_profile([2,1])


### PR DESCRIPTION
Adopt the agreed upon directory naming convention, which is to use `sage.modules.finitely_presented_over_the_steenrod_algebra`. This used to be `sage.modules.fp_modules`.

This was part of an older (not merged) pull request that also contained a fix for a zero element. This pull request only contains the naming convention change, not that zero element fix.