### PR TITLE
Fix wrong type of zero element issue

### DIFF
--- a/free_module.py
+++ b/free_module.py
@@ -199,7 +199,17 @@ class FreeModule(UniqueRepresentation, SageModule):
         # and the total running time of the entire computation dropped from
         # 57 to 21 seconds by adding the optimization.
         #
-        return self._element_constructor_(sum([c*element for c, element in zip(coordinates, basis_elements) if c != 0]))
+        element = sum([c*element for c, element in zip(coordinates, basis_elements) if c != 0])
+        if element == 0: 
+            # The previous sum was over the empty list, yielding the integer
+            # 0 as a result, rather than a module element.
+            # Fix this by calling the constructor.
+            return self._element_constructor_(0)
+        else: 
+            # The sum defining element is of the correct type. We avoid 
+            # calling the constructor unnecessarily, which seems to
+            # save time.
+            return element
 
     @cached_method
     def vector_presentation(self, n):


### PR DESCRIPTION
This is the fix for getting the wrong type (integer instead of module element) in case the list over which the sum is taken is empty.

@sverre320 , you mentioned that maybe you have some local changes that would make this fix obsolete. If that's the case then feel free to decline this PR. :)