### PR TITLE
Remove hash tests

### DIFF
--- a/fp_element.py
+++ b/fp_element.py
@@ -432,14 +432,6 @@ class FP_Element(SageModuleElement):
         r"""
         A hash value representing this element.
 
-        TESTS::
-
-            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.free_module import *
-            sage: A2 = SteenrodAlgebra(2, profile=(3,2,1))
-            sage: M = FreeModule((0,1), A2)
-            sage: M.an_element(127).__hash__()
-            6795291966596493067
-
         """
         return hash(self.coefficients())
 

--- a/free_element.py
+++ b/free_element.py
@@ -459,14 +459,6 @@ class FreeModuleElement(SageModuleElement):
         r"""
         A hash value representing this element.
 
-        TESTS::
-
-            sage: from sage.modules.finitely_presented_over_the_steenrod_algebra.free_module import *
-            sage: A2 = SteenrodAlgebra(2, profile=(3,2,1))
-            sage: M = FreeModule((0,1), A2)
-            sage: M.an_element(127).__hash__()
-            6795291966596493067
-
         """
         return hash(self._coefficients)
 


### PR DESCRIPTION
Remove the hash tests, since it seems that hashing has changed between python 2 and 3:

Python 2:
```python
>>> sys.version
'2.7.17 (default, Oct 24 2019, 12:57:47) \n[GCC 4.2.1 Compatible Apple LLVM 11.0.0 (clang-1100.0.33.8)]'
>>> hash('a')
12416037344
>>> 
```

Python 3:
```python
>>> sys.version
'3.7.7 (default, Mar 10 2020, 15:43:03) \n[Clang 11.0.0 (clang-1100.0.33.17)]'
>>> hash('a')
-7073182127055068966
>>> 
```