### PR TITLE
Fixed bug when computing the degree of a morphism

### DIFF
--- a/fp_morphism.py
+++ b/fp_morphism.py
@@ -281,9 +281,19 @@ class FP_ModuleMorphism(SageMorphism):
 
             sage: homspace.zero().degree() is None
             True
+    
+        TESTS::
+
+            sage: M = FP_Module([7], algebra=SteenrodAlgebra(p=2))
+            sage: N = FP_Module([0], algebra=SteenrodAlgebra(p=2), relations=[[Sq(1)]])
+            sage: f = Hom(M,N)([Sq(1)*N.generator(0)])
+            sage: f == Hom(M,N).zero()
+            True
+            sage: f.degree() is None
+            True
 
         """
-        return self.free_morphism.degree()
+        return None if self.is_zero() else self.free_morphism.degree()
 
 
     def values(self):


### PR DESCRIPTION
The old code did not take into account relations when deciding the degree of a homomorphism.  This is OK for non-trivial maps, but not for zero maps.