### PR TITLE
Raise an error when creating a module over an algebra which is not a …

### DIFF
--- a/fpa_module.py
+++ b/fpa_module.py
@@ -808,7 +808,7 @@ TESTS:
     sage: FPA_Module([0], algebra=ZZ)
     Traceback (most recent call last):
     ...
-    TypeError: This module class can only be instanciated when the algebra argument is an instance of sage.algebras.steenrod.steenrod_algebra.SteenrodAlgebra_generic
+    TypeError: This module class can only be instantiated when the algebra argument is an instance of sage.algebras.steenrod.steenrod_algebra.SteenrodAlgebra_generic
 
 AUTHORS:
 
@@ -890,7 +890,7 @@ class FPA_Module(FP_Module):
         # Make sure that we are creating the module over some Steenrod algebra.
         from sage.algebras.steenrod.steenrod_algebra import SteenrodAlgebra_generic
         if not isinstance(algebra, SteenrodAlgebra_generic):
-            raise TypeError('This module class can only be instanciated when the algebra argument '
+            raise TypeError('This module class can only be instantiated when the algebra argument '
                 'is an instance of sage.algebras.steenrod.steenrod_algebra.SteenrodAlgebra_generic')
 
         # Call the base class constructor.


### PR DESCRIPTION
Mike, your examples regarding the `algebra` method reminded me that we do not check the algebra input argument to the class constructor of FPA_Module.  This change adds such a check and raises a type error if the algebra is not one of the Steenrod algebras.